### PR TITLE
Fix the font_loader on the Linux, where some font names use underscores

### DIFF
--- a/pypdflite/font_loader.py
+++ b/pypdflite/font_loader.py
@@ -39,7 +39,7 @@ class Font_Loader(object):
                 if ext == '.ttf':
                     if root[0].lower() in english:
                         source = os.path.join(dirName, item)
-                        name = root.lower()
+                        name = root.lower().replace('_', ' ')
                         if ' bold' in name:
                             name = name.replace(' bold', '_bold')
                             if ' italic' in name:


### PR DESCRIPTION
rather than spaces in their names. So put the names back to spaces.

This addresses issue #5
