### PR TITLE
Transforms

### DIFF
--- a/bin/transformtest.py
+++ b/bin/transformtest.py
@@ -1,0 +1,72 @@
+from pypdflite.pdflite import PDFLite
+from pypdflite.pdfobjects.pdftransforms import PDFTransform
+from pypdflite.pdfobjects.pdftext import PDFText
+
+
+def TransformTest():
+
+    #Create PDFLITE object, initialize with path & filename.
+    writer = PDFLite("generated/Transform.pdf", orientation="P")
+    # If desired (in production code), set compression
+    writer.set_compression(False)
+
+    # Set general information metadata
+    writer.set_information(title="Testing Transform")  # set optional information
+
+    # Use get_document method to get the generated document object.
+    document = writer.get_document()
+    
+    document.add_text("Transform test")
+    
+    document.add_newline(4)
+    
+    
+    text = PDFText (document.session, document.page, None)
+    text._text('transform')
+    
+    text.cursor.x_plus(20)
+    text.text_rotate(90)
+    text._text('transform')
+    
+    text = PDFText (document.session, document.page, None)
+    text.cursor.x_plus(20)
+    text.text_rotate(180)
+    text._text('transform')
+    
+    text = PDFText (document.session, document.page, None)
+    text.cursor.x_plus(20)
+    text.text_rotate(-90)
+    text._text('transform')
+    
+    document.add_newline(5)
+
+    text = PDFText (document.session, document.page, None)
+    text._text('transform  ')
+    text.text_scale(2, 0.5)
+    text._text('transform')
+
+    document.add_newline(2)
+    text = PDFText (document.session, document.page, None)
+    text._text('transform  ')
+    text.text_scale(0.5, 2)
+    text._text('transform')
+
+    document.add_newline(2)
+    text = PDFText (document.session, document.page, None)
+    text._text('transform  ')
+    text.text_skew(30, 0)
+    text._text('transform')
+
+    document.add_newline(2)
+    text = PDFText (document.session, document.page, None)
+    text._text('transform  ')
+    text.text_skew(0, 30)
+    text._text('transform')
+
+    
+    # Close writer
+    writer.close()
+
+
+if __name__ == "__main__":
+    TransformTest()

--- a/pypdflite/pdfobjects/pdftransforms.py
+++ b/pypdflite/pdfobjects/pdftransforms.py
@@ -20,6 +20,7 @@ class PDFTransform(object):
         self.page = page
 
         self._currentMatrix = (1., 0., 0., 1., 0., 0.)
+        self._textMatrix = (1., 0., 0., 1., 0., 0.)
 
     def saveState(self):
         """Save the current graphics state to be restored later by restoreState.
@@ -37,11 +38,11 @@ class PDFTransform(object):
         
         
         """
-        self.session._out('q')
+        self.session._out('q', self.page)
 
     def restoreState(self):
         """restore the graphics state to the matching saved state (see saveState)."""
-        self.session._out('Q')
+        self.session._out('Q', self.page)
 
         
     def transform(self, a,b,c,d,e,f):
@@ -52,8 +53,8 @@ class PDFTransform(object):
         self._currentMatrix = (a0*a+c0*b,    b0*a+d0*b,
                                a0*c+c0*d,    b0*c+d0*d,
                                a0*e+c0*f+e0, b0*e+d0*f+f0)
-
-        self.session._out ('%.2f %.2f %.2f %.2f %.2f %.2f cm' % (a,b,c,d,e,f))
+        a1,b1,c1,d1,e1,f1 = self._currentMatrix
+        self.session._out ('%.2f %.2f %.2f %.2f %.2f %.2f cm' % (a1,b1,c1,d1,e1,f1), self.page)
 
     def absolutePosition(self, x, y):
         """return the absolute position of x,y in user space w.r.t. default user space"""
@@ -83,4 +84,3 @@ class PDFTransform(object):
         tanAlpha = tan(alpha * pi / 180)
         tanBeta  = tan(beta  * pi / 180)
         self.transform(1, tanAlpha, tanBeta, 1, 0, 0)
-    

--- a/runexamples.py
+++ b/runexamples.py
@@ -10,6 +10,7 @@ from bin.jpgtest import JPGTest
 from bin.pagenumbertest import PageNumberTest
 from bin.pngsizetest import ImageSizeTest
 from bin.ellipsetest import EllipseTest
+from bin.transformtest import TransformTest
 
 def main():
     print "Running TextTest"
@@ -36,7 +37,8 @@ def main():
     ImageSizeTest()
     print "Running EllipseTest"
     EllipseTest()
-
+    print "Running TransormTest"
+    TransformTest()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Add two different types of transformations to the library. 

The first extends PDFText to allow transforming text. The operations include scaling, rotation, skewing, and positioning. The positioning can be done using the cursor, but with this option the positioning can be combined with other options. 

I added this option mostly to allow some text rotation on the PDFs I'm creating, but extended it to the general case. 

The difficult part here is the internal cursor tracking doesn't take into account of the transformations. So, for example, scaling the text down or up in the horizontal direction, the page cursor won't correctly know the location of where to place the next text. So use with caution. 

Second is to add a PDFTransforms class, which allows performing the same options (scale, rotation, skewing, positioning) on graphics (e.g. lines and ellipses). This is untested, and like the text transformation, may leave the page state different from the library state. 
