### PR TITLE
Fix color test

### DIFF
--- a/pypdflite/pdfobjects/pdfcolor.py
+++ b/pypdflite/pdfobjects/pdfcolor.py
@@ -62,7 +62,7 @@ class PDFColor(object):
             ans = False
         elif test_color.color_type != self.color_type:
             ans = False
-        elif self.name == test_color.name:
+        elif self.name is not None and self.name == test_color.name:
             ans = True
         elif (self.red == test_color.red and
               self.blue == test_color.blue and


### PR DESCRIPTION
Fix a bug in the PDFColor._is_equals(). Python treats `None == None` as true. 

The problem was if you are using derivative of PDFDraw, and drawing with different colors created by number (but not name), the colors would not change. `PDFDraw._draw_color()` checks if the color has changed using the _is_equals(). But if you started with a color using a number, then tries to switch to another color by number, it is equals says they are, even if the number are different. 
