### PR TITLE
Fix the compression mode not working in Python3

### DIFF
--- a/bin/barcharttest.py
+++ b/bin/barcharttest.py
@@ -12,7 +12,7 @@ def BarChartTest(test_dir):
     writer = PDFLite(os.path.join(test_dir, "tests/BarChart.pdf"))
 
     # Set compression defaults to False
-    writer.set_compression(False)
+    writer.set_compression(True)
 
     # Set document metadata
     writer.set_information(title="Testing Bar Chart")  # set optional information

--- a/pypdflite/pdflite.py
+++ b/pypdflite/pdflite.py
@@ -117,7 +117,7 @@ class PDFLite(object):
         """ Standard first line in a PDF. """
         self.session._out('%%PDF-%s' % self.pdf_version)
         if self.session.compression:
-            self.session.buffer += '%' + chr(235) + chr(236) + chr(237) + chr(238) + "\n"
+            self.session._out('%' + chr(235) + chr(236) + chr(237) + chr(238))
 
     def _put_pages(self):
         """ First, the Document object does the heavy-lifting for the
@@ -288,7 +288,7 @@ class PDFLite(object):
         self.session._out('/ID [ <%s> <%s>]' % (md5.hexdigest(),md5.hexdigest()))
         self.session._out('>>')
         self.session._out('startxref')
-        self.session._out(startxref)
+        self.session._out(str(startxref))
         self.session._out('%%EOF')
 
     def _output_to_file(self):
@@ -300,7 +300,7 @@ class PDFLite(object):
         f = open(self.filepath, 'wb')
         if not f:
             raise Exception('Unable to create output file: ', self.filepath)
-        f.write(self.session.buffer.encode())
+        f.write(self.session.buffer)
         f.close()
 
     def _output_to_string(self):

--- a/pypdflite/pdfobjects/ttfonts.py
+++ b/pypdflite/pdfobjects/ttfonts.py
@@ -96,7 +96,6 @@ class TTFontFile:
         self.entrySelector = self.read_ushort()
         self.rangeShift = self.read_ushort()
         
-        print ("Tables: %d, searchRange: %d, Entry: %d, Range: %d" % (self.numTables, self.searchRange, self.entrySelector, self.rangeShift) )
         self.tables = {}
         for _ in range(self.numTables):
             record = {}

--- a/pypdflite/session.py
+++ b/pypdflite/session.py
@@ -21,7 +21,7 @@ class _Session(object):
         self.parent = parent
 
         # Central buffer for storing PDF code not in pages.
-        self.buffer = ''
+        self.buffer = b''
 
         # Offest is used to calculate the binary lengths in the cross-reference
         # section
@@ -92,9 +92,12 @@ class _Session(object):
 
         """
         if page is not None:
-            page.buffer += str(stream) + "\n"
+            page.buffer += stream + "\n"
         else:
-            self.buffer += str(stream) + "\n"
+            if isinstance(stream, str):
+                self.buffer += stream.encode() + b"\n"
+            else:
+                self.buffer += stream + "\n".encode()
 
     def _put_stream(self, stream):
         """ Creates a PDF text stream sandwich.

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from distutils.core import setup
 
 setup(
     name='PyPDFLite',
-    version='0.1.40',
+    version='0.1.50',
     author='Katerina Hanson',
     author_email='katerina.hanson@gmail.com',
     packages=['pypdflite', 'pypdflite.pdfobjects'],
     scripts=['runexamples.py'],
     license='LICENSE.md',
-    description='Simple PDF Writer.',
+    description='Simple PDF Writer for Python 3',
     long_description=open('README.txt').read(),
     url='https://github.com/katerina7479/pypdflite',
     download_url='https://github.com/katerina7479/pypdflite/tarball/0.1'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='PyPDFLite',
-    version='0.1.50',
+    version='0.1.41',
     author='Katerina Hanson',
     author_email='katerina.hanson@gmail.com',
     packages=['pypdflite', 'pypdflite.pdfobjects'],


### PR DESCRIPTION
Remove a piece of debugging code left in during the port to Python 3

Set the version number a little more reasonably. 