### PR TITLE
Made more resilient to different file names

### DIFF
--- a/pypdflite/pdfdocument.py
+++ b/pypdflite/pdfdocument.py
@@ -587,10 +587,10 @@ class PDFDocument(object):
                     name = os.path.splitext(image_string)[0]  # Specify it
                 myimage = self._get_image(name)
                 if not myimage:  # New image
-                    extension = os.path.splitext(image_string)[1]
+                    extension = os.path.splitext(image_string)[1].lower()
                     if extension == '.png':
                         myimage = PDFPNG(self.session, image_string, name)
-                    elif extension == '.jpg':
+                    elif extension == '.jpg' or extension == '.jpeg':
                         myimage = PDFJPG(self.session, image_string, name)
                     else:
                         raise Exception("Image format %s not supported" % extension)


### PR DESCRIPTION
Hi!  On OS's that are case sensitive the literal comparison to lowercase extensions doesn't work well... Also, sometimes folks use jpeg.  The right answer is probably to use the built in mime types module but will look at that later